### PR TITLE
Add option to exclude certain items from the fertilizer nerf

### DIFF
--- a/src/main/java/insane96mcp/iguanatweaksreborn/modules/farming/feature/NerfedBonemealFeature.java
+++ b/src/main/java/insane96mcp/iguanatweaksreborn/modules/farming/feature/NerfedBonemealFeature.java
@@ -1,6 +1,11 @@
 package insane96mcp.iguanatweaksreborn.modules.farming.feature;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import insane96mcp.iguanatweaksreborn.base.Modules;
+import insane96mcp.iguanatweaksreborn.common.classutils.IdTagMatcher;
 import insane96mcp.iguanatweaksreborn.modules.farming.FarmingModule;
 import insane96mcp.iguanatweaksreborn.modules.farming.classutils.CropsRequireWater;
 import insane96mcp.iguanatweaksreborn.modules.farming.classutils.NerfedBonemeal;
@@ -13,21 +18,22 @@ import net.minecraft.block.BeetrootBlock;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.CropsBlock;
 import net.minecraft.block.StemBlock;
+import net.minecraft.item.Item;
 import net.minecraftforge.common.ForgeConfigSpec;
 import net.minecraftforge.event.entity.player.BonemealEvent;
 import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
-
-import java.util.Collections;
 
 @Label(name = "Nerfed Bonemeal", description = "Bonemeal is no longer so OP")
 public class NerfedBonemealFeature extends Feature {
 
 	private final ForgeConfigSpec.ConfigValue<NerfedBonemeal> nerfedBonemealConfig;
 	private final ForgeConfigSpec.ConfigValue<Double> bonemealFailChanceConfig;
+	private final ForgeConfigSpec.ConfigValue<List<? extends String>> blacklistConfig;
 
 	public NerfedBonemeal nerfedBonemeal = NerfedBonemeal.NERFED;
 	public double bonemealFailChance = 0d;
+	public List<IdTagMatcher> blacklist;
 
 	public NerfedBonemealFeature(Module module) {
 		super(Config.builder, module);
@@ -38,6 +44,9 @@ public class NerfedBonemealFeature extends Feature {
 		bonemealFailChanceConfig = Config.builder
 				.comment("Makes Bone Meal have a chance to fail to grow crops. 0 to disable, 100 to disable bonemeal.")
 				.defineInRange("Bonemeal Fail Chance", bonemealFailChance, 0.0d, 100d);
+		blacklistConfig = Config.builder
+                .comment("Fertilizers that will not be affected by the bonemeal nerf. Each entry has an item or tag. E.g. [\"charcoal_pit:fertilizer\"].")
+                .defineList("Fertilizer Blacklist", Arrays.asList(), o -> o instanceof String);
 		Config.builder.pop();
 	}
 
@@ -46,6 +55,7 @@ public class NerfedBonemealFeature extends Feature {
 		super.loadConfig();
 		this.nerfedBonemeal = this.nerfedBonemealConfig.get();
 		this.bonemealFailChance = this.bonemealFailChanceConfig.get();
+		this.blacklist = IdTagMatcher.parseStringList(blacklistConfig.get());
 	}
 
 	/**
@@ -66,6 +76,10 @@ public class NerfedBonemealFeature extends Feature {
 		}
 		if (this.nerfedBonemeal.equals(NerfedBonemeal.DISABLED))
 			return;
+		if (this.isInBlacklist(event.getStack().getItem()))
+			return;
+		
+		
 		BlockState state = event.getWorld().getBlockState(event.getPos());
 		if (state.getBlock() instanceof CropsBlock) {
 			boolean isBeetroot = state.getBlock() instanceof BeetrootBlock;
@@ -117,5 +131,15 @@ public class NerfedBonemealFeature extends Feature {
 			return;
 		event.getWorld().setBlockState(event.getPos(), state, 3);
 		event.setResult(Event.Result.ALLOW);
+	}
+	
+	protected boolean isInBlacklist(Item item) {
+        for (IdTagMatcher blacklistEntry : blacklist) {
+        	if (blacklistEntry.isInTagOrItem(item, null)) {
+                return true;
+            }
+        }
+
+		return false;
 	}
 }


### PR DESCRIPTION
Adds an option to add specific exceptions to the bonemeal nerf for fertilizer items added by other mods. 

For example, I might want to nerf vanilla bonemeal, but not the fertilizer item added by Charcoal Pit as it takes more manual effort to make. 

Feel free to reject this if it is unwanted.