### PR TITLE
Add a null check in the ProtectionEnchantmentMixin

### DIFF
--- a/src/main/java/insane96mcp/iguanatweaksreborn/mixin/ProtectionEnchantmentMixin.java
+++ b/src/main/java/insane96mcp/iguanatweaksreborn/mixin/ProtectionEnchantmentMixin.java
@@ -23,7 +23,7 @@ public class ProtectionEnchantmentMixin extends Enchantment {
 
 	@Override
 	public boolean isTreasureOnly() {
-		if (this.type == ProtectionEnchantment.Type.ALL && Modules.combat.stats.protectionNerf == Stats.ProtectionNerf.DISABLE)
+		if (this.type == ProtectionEnchantment.Type.ALL && Modules.combat != null && Modules.combat.stats.protectionNerf == Stats.ProtectionNerf.DISABLE)
 			return true;
 		return super.isTreasureOnly();
 	}
@@ -37,14 +37,14 @@ public class ProtectionEnchantmentMixin extends Enchantment {
 
 	@Override
 	public boolean isDiscoverable() {
-		if (this.type == ProtectionEnchantment.Type.ALL && Modules.combat.stats.protectionNerf == Stats.ProtectionNerf.DISABLE)
+		if (this.type == ProtectionEnchantment.Type.ALL && Modules.combat != null && Modules.combat.stats.protectionNerf == Stats.ProtectionNerf.DISABLE)
 			return false;
 		return super.isDiscoverable();
 	}
 
 	@Override
 	public int getMaxLevel() {
-		if (this.type == ProtectionEnchantment.Type.ALL && Modules.combat.stats.protectionNerf != Stats.ProtectionNerf.NONE)
+		if (this.type == ProtectionEnchantment.Type.ALL && Modules.combat != null && Modules.combat.stats.protectionNerf != Stats.ProtectionNerf.NONE)
 			return 3;
 
 		return 4;


### PR DESCRIPTION
If another mod has a missing dependency the mod loading stops before the combat module is fully initialized, 
**EnchantedBookItem** calls **ProtectionEnchantment#getMaxLevel** before forge has a chance to get to the missing dependency screen causing the nullpointer:
**java.lang.NullPointerException: Cannot read field "stats" because "insane96mcp.iguanatweaksreborn.module.Modules.combat" is null**

This PR fixes #210 