### PR TITLE
attack invincibility cooldown fix

### DIFF
--- a/src/main/java/insane96mcp/iguanatweaksreborn/module/combat/AttackInvincibility.java
+++ b/src/main/java/insane96mcp/iguanatweaksreborn/module/combat/AttackInvincibility.java
@@ -37,7 +37,7 @@ public class AttackInvincibility extends Feature {
 				|| !serverPlayer.getMainHandItem().getAttributeModifiers(EquipmentSlot.MAINHAND).containsKey(Attributes.ATTACK_SPEED))
 			return;
 
-		int time = (int) ((1f / serverPlayer.getAttribute(Attributes.ATTACK_SPEED).getValue()) * 20);
+		int time = (int) ((1f / serverPlayer.getAttribute(Attributes.ATTACK_SPEED).getValue()) * 20 + 10);
 		event.getEntity().invulnerableTime = time;
 		event.getEntity().hurtTime = time;
 		InvulnerableTimeMessageSync.sync((ServerLevel) event.getEntity().level(), event.getEntity(), time);


### PR DESCRIPTION
When invulnerableTime is 10 or less, the game treats it as an instant cooldown. It is a weird quirk of the game that I don't really understand but this does fix it. Attack speed from 2-10 will now decrease invincibility from 10 ticks to 0 respectively.